### PR TITLE
fixed typo in transform_translate() ignoring units

### DIFF
--- a/turfpy/transformation.py
+++ b/turfpy/transformation.py
@@ -665,7 +665,7 @@ def transform_translate(
     ):
         nonlocal distance, direction, units, z_translation
         new_coords = get_coord(
-            rhumb_destination(GeoPoint(coord), distance, direction, {units: units})
+            rhumb_destination(GeoPoint(coord), distance, direction, {"units": units})
         )
         coord[0] = new_coords[0]
         coord[1] = new_coords[1]


### PR DESCRIPTION
Hi!
I found typo in transform_translate() which causes to ignore units parameter so "km" was always in use. I checked also rest of code in repo and no other typos like that are present.