### PR TITLE
Use get_coord in destination to pass a Point

### DIFF
--- a/turfpy/measurement.py
+++ b/turfpy/measurement.py
@@ -366,7 +366,9 @@ def length(geojson, units: str = "km"):
 # ----------- Destination --------------#
 
 
-def destination(origin: Union[Feature, Point], distance, bearing, options: dict = {}) -> Feature:
+def destination(
+    origin: Union[Feature, Point], distance, bearing, options: dict = {}
+) -> Feature:
     """
     Takes a Point and calculates the location of a destination point given a distance in
     degrees, radians, miles, or kilometers and bearing in degrees.

--- a/turfpy/measurement.py
+++ b/turfpy/measurement.py
@@ -366,7 +366,7 @@ def length(geojson, units: str = "km"):
 # ----------- Destination --------------#
 
 
-def destination(origin: Feature, distance, bearing, options: dict = {}) -> Feature:
+def destination(origin: Union[Feature, Point], distance, bearing, options: dict = {}) -> Feature:
     """
     Takes a Point and calculates the location of a destination point given a distance in
     degrees, radians, miles, or kilometers and bearing in degrees.
@@ -389,7 +389,7 @@ def destination(origin: Feature, distance, bearing, options: dict = {}) -> Featu
     >>> options = {'units': 'mi'}
     >>> destination(origin,distance,bearing,options)
     """
-    coordinates1 = origin["geometry"]["coordinates"]
+    coordinates1 = get_coord(origin)
     longitude1 = radians(float(coordinates1[0]))
     latitude1 = radians(float(coordinates1[1]))
     bearingRad = radians(float(bearing))


### PR DESCRIPTION
In accordance with [the original implementation in turf.js](https://github.com/Turfjs/turf/blob/32f64cfb37b0e50332ff3fa78c880cbcc597507b/packages/turf-destination/index.ts#L52) and other functions in turfpy (e.g., [`distance`](https://github.com/omanges/turfpy/blob/986996268626e7bc4bec71091a2ef1af43c5b68b/turfpy/measurement.py#L112-L113)), this PR leverages `get_coord` so that a `Point` instance can be passed to the `destination` function as well.