### PR TITLE
Fix centroid calculation - don't revisit wrapping coordinate

### DIFF
--- a/turfpy/__version__.py
+++ b/turfpy/__version__.py
@@ -1,3 +1,3 @@
 """Project version information."""
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/turfpy/measurement.py
+++ b/turfpy/measurement.py
@@ -452,7 +452,7 @@ def centroid(geojson, properties: dict = None) -> Feature:
         y_sum += coord[1]
         length += 1
 
-    coord_each(geojson, _callback_coord_each)
+    coord_each(geojson, _callback_coord_each, True)
     point = Point((x_sum / length, y_sum / length))
     return Feature(geometry=point, properties=properties if properties else {})
 


### PR DESCRIPTION
And bump version to 0.0.8

Probably needs tests fixes

The fix matches what was done in Turf.js - https://github.com/Turfjs/turf/pull/1894/files#diff-c6bf1e0676ca3aa8e5b4be83c45a17b29bcd63a18caa404ac1ddb85004257896