### PR TITLE
Use shapely.ops.unary_union instead of shapely.ops.cascaded_union

### DIFF
--- a/turfpy/__version__.py
+++ b/turfpy/__version__.py
@@ -1,3 +1,3 @@
 """Project version information."""
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/turfpy/transformation.py
+++ b/turfpy/transformation.py
@@ -18,7 +18,7 @@ from scipy.spatial import Delaunay, Voronoi
 from shapely import geometry as geometry
 from shapely.geometry import LineString as ShapelyLineString
 from shapely.geometry import MultiPoint, MultiPolygon, Point, mapping, shape
-from shapely.ops import cascaded_union, clip_by_rect, polygonize, unary_union
+from shapely.ops import clip_by_rect, polygonize, unary_union
 
 from turfpy.helper import get_coord, get_coords, get_geom, get_type, length_to_degrees
 from turfpy.measurement import (
@@ -280,7 +280,7 @@ def union(
             if "properties" in f.keys():
                 properties_list.append(f["properties"])
 
-    result = cascaded_union(shapes)
+    result = unary_union(shapes)
     result = mapping(result)
     properties = merge_dict(properties_list)
 
@@ -351,7 +351,7 @@ def _alpha_shape(points, alpha):
 
     m = geometry.MultiLineString(edge_points)
     triangles = list(polygonize(m))
-    return cascaded_union(triangles), edge_points
+    return unary_union(triangles), edge_points
 
 
 def get_points(features):


### PR DESCRIPTION
The `cascaded_union` function is [deprecated](https://shapely.readthedocs.io/en/stable/manual.html#shapely.ops.cascaded_union) in the `shapely` library now. Using this, we have a deprecation warning in text output:

```
lib/python3.9/site-packages/turfpy/transformation.py:283: ShapelyDeprecationWarning: The 'cascaded_union()' function is deprecated. Use 'unary_union()' instead.
    result = cascaded_union(shapes)
```

Instead of this, since `shapely 1.8` we must [use](https://shapely.readthedocs.io/en/stable/reference/shapely.unary_union.html) `shapely.ops.unary_union`.

Here is a fix of the deprecation warning mentioned above.